### PR TITLE
MR: feat: add fixed output field

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,11 +21,10 @@ jobs:
           ci_server_url: ${{ vars.PSONO_SERVER_URL }}
           secret_id: ${{ secrets.PSONO_GITHUB_REGISTRY_ID }}
           secret_type: 'env'
-          secret_fields: "CI_REGISTRY CI_REGISTRY_USER"
+          secret_fields: CI_REGISTRY,CI_REGISTRY_USER
           mask_secrets: CI_REGISTRY_USER
 
       - name: Check outputs
         run: |
-          secrets=(${{ steps.selftest.outputs.secrets }})
-          test "${secrets[0]}" == "CI_REGISTRY=ghcr.io"
-          test "${secrets[1]}" == "CI_REGISTRY_USER=jfheinrich"
+          test "${{ steps.selftest.outputs.secret1 }}" == "ghcr.io"
+          test "${{ steps.selftest.outputs.secret2 }}" == "jfheinrich"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # psono-secret-whisperer
 A GitHub Action for securely retrieving secrets from PSONO server
+
+## Usage
+
+```yaml
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from PSONO
+        id: psono-secrets
+        uses: jfheinric-eu/psono-secret-whisperer@v1
+        with:
+            ci_api_key_id: ${{ secrets.CI_API_KEY_ID }}
+            ci_api_key_secret_hex: ${{ secrets.CI_API_KEY_SECRET_HEX }}
+            ci_server_url: 'https://your-psono-server.com'
+            secret_id: ${{ secrets.SECRET_ID }}
+            secret_type: 'env'
+            secret_fields: 'API_KEY DATABASE_URL,OTHER_SECRET'
+            mask_secrets: 'API_KEY,OTHER_SECRET'
+
+      # Access secrets
+      - name: Use secrets
+        run: |
+          echo "API Key: ${{ steps.selftest.outputs.secret1 }}"
+          echo "Database URL: ${{ steps.selftest.outputs.secret2 }}"
+```
+
+## Inputs
+
+| Input                   | Description                                           | Required | Default           |
+|-------------------------|-------------------------------------------------------|----------|-------------------|
+| `ci_api_key_id`         | PSONO API key                                         | Yes      | -                 |
+| `ci_api_key_secret_hex` | PSONO API key                                         | Yes      | -                 |
+| `ci_server_url`         | URL of your PSONO server                              | Yes      | -                 |
+| `secret_id`             | secret id to fetch                                    | Yes      | -                 |
+| `secret_fields`         | Comma-separated list of secret keys to retrieve       | No       | username,password |
+| `mask_secrets`          | Comma-separated list of secret keys to masked         | No       | -                 |
+
+## Outputs
+
+The action provides following outputs:
+
+Output field from `secret1` till `secret10`. `secret1` is the value for the first field in `inputs.secret_fields` and so on.
+
+## Security Recommendations
+
+- Always use GitHub secrets to store your PSONO credentials
+- Limit the secret keys you retrieve to only what you need
+- Consider using GitHub's OIDC support for even more secure authentication
+
+## Requirements
+
+The action requires:
+- A PSONO server that's accessible from GitHub Actions
+- Valid PSONO credentials with access to the requested secrets
+
+## License
+
+This GitHub Action is released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -23,14 +23,32 @@ inputs:
     description: "Type of secret tp fetch: env or secret, default: secret"
     default: "secret"
   secret_fields:
-    description: "Space-separated list of secret keys to retrieve, default: username password"
+    description: "Comma-separated list of secret keys to retrieve, default: username password"
     default: "username password"
   mask_secrets:
     description: "Comma-separated list of secret keys to be masked"
 
 outputs:
-  secrets:
-    description: "Spaces separate list with keys/value pairs"
+  secret1:
+    description: "Secret of the first field in inputs.secret_fields"
+  secret2:
+    description: "Secret of the second field in inputs.secret_fields"
+  secret3:
+    description: "Secret of the third field in inputs.secret_fields"
+  secret4:
+    description: "Secret of the fourth field in inputs.secret_fields"
+  secret5:
+    description: "Secret of the fifth field in inputs.secret_fields"
+  secret6:
+    description: "Secret of the sixth field in inputs.secret_fields"
+  secret7:
+    description: "Secret of the seventh field in inputs.secret_fields"
+  secret8:
+    description: "Secret of the eighth field in inputs.secret_fields"
+  secret9:
+    description: "Secret of the ninth field in inputs.secret_fields"
+  secret10:
+    description: "Secret of the tenth field in inputs.secret_fields"
 
 runs:
   using: "docker"

--- a/main.py
+++ b/main.py
@@ -41,8 +41,13 @@ def main():
 
     cmd.append(os.environ["INPUT_SECRET_ID"])
 
-    secrets = ""
-    for field in os.environ["INPUT_SECRET_FIELDS"].split(" "):
+    count = 0
+    for field in os.environ["INPUT_SECRET_FIELDS"].split(","):
+        count += 1
+        if count > 10:
+            print("To much fields, only ten fields allowed")
+            exit(100)
+
         cmdval = cmd.copy()
         cmdval.append(field)
         try:
@@ -61,10 +66,7 @@ def main():
         if field in mask_secrets:
             print(f'::add-mask::{secret.stdout}\n')
 
-        secrets += f'{field}="{secret.stdout}" '
-
-    secrets = secrets[:-1]
-    set_github_action_output("secrets", secrets)
+        set_github_action_output(f'secret{count}', secret.stdout)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def main():
             print(f"Error: {e}")
             exit(2)
         except FileNotFoundError:
-            print(f"Error: Command '{cmdval[0]}' not found")
+            print("Error: Command psonoci not found")
             exit(3)
 
         if field in mask_secrets:


### PR DESCRIPTION
# Task

Github actions can't create dynamically output fields, so wie declare 10 fixed fields secret1...secret10 to fix it

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#3](https://github.com/jfheinrich-eu/psono-secret-whisperer/pull/3))

### Other
- add fixed output field
- Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

<!--- END AUTOGENERATED NOTES --->


# Checklist

- [✅ ] I have performed a self-review of my own code
- [✅ ] I have added tests to cover my changes