### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   bump-tag-version:
     name: Bump and Tag Version


### PR DESCRIPTION
Potential fix for [https://github.com/jfheinrich-eu/psono-secret-whisperer/security/code-scanning/13](https://github.com/jfheinrich-eu/psono-secret-whisperer/security/code-scanning/13)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are likely required:
- `contents: read` to read repository contents.
- `pull-requests: write` to interact with pull requests (if applicable).
- Additional permissions can be added if specific actions require them.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`bump-tag-version`) to limit permissions for that job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
<!--- START AUTOGENERATED NOTES --->
# Contents ([#25](https://github.com/jfheinrich-eu/psono-secret-whisperer/pull/25))

### Other
- Potential fix for code scanning alert no. 13: Workflow does not contain permissions

<!--- END AUTOGENERATED NOTES --->